### PR TITLE
Added WikiNEuRal Multilingual Dataset for Named Entity Recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,48 @@ Datasets to train supervised classifiers for Named-Entity Recognition
  * leNER-br
  * Peres2017
  * [WikiANN](https://huggingface.co/datasets/wikiann)
+ * [WikiNEuRal](https://github.com/Babelscape/wikineural)
+
 
 <a name="de"></a>
 ### German
  * [GermEval2014](https://github.com/davidsbatista/NER-datasets/tree/master/GermEval2014)
  * [Europeana Newspapers](https://github.com/EuropeanaNewspapers/ner-corpora)
  * [WikiANN](https://huggingface.co/datasets/wikiann)
+ * [WikiNEuRal](https://github.com/Babelscape/wikineural)
  
 <a name="nl"></a>
 ### Dutch
  * [Europeana Newspapers](https://github.com/EuropeanaNewspapers/ner-corpora)
  * [WikiANN](https://huggingface.co/datasets/wikiann)
+ * [WikiNEuRal](https://github.com/Babelscape/wikineural)
 
 <a name="fr"></a>
 ### French
  * [Europeana Newspapers](https://github.com/EuropeanaNewspapers/ner-corpora)
  * [WikiANN](https://huggingface.co/datasets/wikiann)
+ * [WikiNEuRal](https://github.com/Babelscape/wikineural)
 
 <a name="en"></a>
 ### English
  * [CONLL2003](https://github.com/davidsbatista/NER-datasets/tree/master/CONLL2003)
  * [W-NUT2017](https://github.com/leondz/emerging_entities_17) Workshop on Noisy User-generated Text: Emerging and Rare entity recognition
  * [WikiANN](https://huggingface.co/datasets/wikiann)
+ * [WikiNEuRal](https://github.com/Babelscape/wikineural)
+
+<a name="it"></a>
+### Italian
+ * [WikiNEuRal](https://github.com/Babelscape/wikineural)
+
+<a name="es"></a>
+### Spanish
+ * [WikiNEuRal](https://github.com/Babelscape/wikineural)
+
+<a name="pl"></a>
+### Polish
+ * [WikiNEuRal](https://github.com/Babelscape/wikineural)
+
+<a name="ru"></a>
+### Russian
+ * [WikiNEuRal](https://github.com/Babelscape/wikineural)
+


### PR DESCRIPTION
WikiNEuRal is a novel high-quality automatically-generated dataset for multilingual NER, recently accepted at EMNLP 2021.
Experiments show how WikiNEuRal data are better than data created using previous state-of-the-art strategies for NER silver-data creation (i.e., WikiNER and WikiANN).

Paper link: https://aclanthology.org/2021.findings-emnlp.215/
Repo link: https://github.com/Babelscape/wikineural

![Comparison between WikiNEuRal, WikiNER and WikiANN(1)](https://user-images.githubusercontent.com/47241515/143891895-bcf99f93-5e02-4720-ab5c-bdce1db318f2.png)

